### PR TITLE
Use `into {}` instead of `apply hash-map`

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -193,7 +193,7 @@
      id-list    (apply list (coll-thaw! s))
      id-vector  (into  [] (coll-thaw! s))
      id-set     (into #{} (coll-thaw! s))
-     id-map     (apply hash-map (coll-thaw! s))
+     id-map     (into {} (map vec (partition 2 (coll-thaw! s))))
      id-coll    (doall (coll-thaw! s))
      id-queue   (into  (PersistentQueue/EMPTY) (coll-thaw! s))
 


### PR DESCRIPTION
I use nippy in production and found an OOM issue caused by the deserialization of a huge map, after monitoring the application for a while, I found it is caused by nippy.

For huge maps, `apply` may cause OOM, because it will realize all the elements of the arglist seq, and construct an `Object[]` to hold them.

I changed this line and use `(into {} ...)` instead of `(apply hash-map ...)`, and it works. The OOM issue could be avoided by this.
