### PR TITLE
replace partial with an anonymous fn ((small) performance optimisation)

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -182,7 +182,7 @@
 (defn coll-thaw!
   "Thaws simple collection types."
   [^DataInputStream s]
-  (repeatedly (.readInt s) (partial thaw-from-stream!* s)))
+  (repeatedly (.readInt s) #(thaw-from-stream!* s)))
 
 (defn coll-thaw-kvs!
   "Thaws key-value collection types."
@@ -234,7 +234,7 @@
      id-old-reader (read-string (.readUTF s))
      id-old-string (.readUTF s)
      id-old-map    (apply hash-map (repeatedly (* 2 (.readInt s))
-                                               (partial thaw-from-stream!* s)))
+                                               #(thaw-from-stream!* s)))
 
      (throw (Exception. (str "Failed to thaw unknown type ID: " type-id))))))
 


### PR DESCRIPTION
Hi Peter, 

It's a small detail but it seems partial induces a little overhead compared to an anonymous fns.

Some numbers for `roundrip`

partial : 
13362
13346
13452

ano fn: 
10988
10897
10951

The gain is not incredible, but it's there. Even tho I also find partial more elegant, it has a small cost and hotspot seems not to want to optimise that. 
