### PR TITLE
Fast serialization for Date and UUID objects

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -11,7 +11,7 @@
   (:import  [java.io DataInputStream DataOutputStream ByteArrayOutputStream
              ByteArrayInputStream]
             [java.lang.reflect Method]
-            [java.util Date]
+            [java.util Date UUID]
             [clojure.lang Keyword BigInt Ratio PersistentQueue PersistentTreeMap
              PersistentTreeSet IPersistentList IPersistentVector IPersistentMap
              IPersistentSet IPersistentCollection IRecord]))
@@ -68,6 +68,7 @@
 (def ^:const id-record     (int 80))
 
 (def ^:const id-date       (int 90))
+(def ^:const id-uuid       (int 91))
 
 ;;; DEPRECATED (old types will be supported only for thawing)
 (def ^:const id-old-reader  (int 1))  ; as of 0.9.2, for +64k support
@@ -177,6 +178,9 @@
          (write-biginteger s (.denominator x)))
 
 (freezer Date id-date (.writeLong s (.getTime x)))
+(freezer UUID id-uuid
+         (.writeLong s (.getMostSignificantBits x))
+         (.writeLong s (.getLeastSignificantBits x)))
 
 (def ^:private head-meta-id (reduce-kv #(assoc %1 %3 %2) {} head-meta))
 
@@ -282,6 +286,7 @@
        (.invoke method class (into-array Object [(thaw-from-stream s)])))
 
      id-date  (Date. (.readLong s))
+     id-uuid  (UUID. (.readLong s) (.readLong s))
 
      ;;; DEPRECATED
      id-old-reader (edn/read-string (.readUTF s))


### PR DESCRIPTION
This patch implements serialization for `java.util.Date` and `java.util.UUID` objects, as discussed in issue #22.

The reason these specific classes are chosen is that these are the default tagged literals (`#inst` and `#uuid`) in Clojure core.
