### PR TITLE
add initial implementation of LZ4 compression

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,9 @@
   :dependencies [[org.clojure/clojure      "1.4.0"]
                  [org.clojure/tools.reader "0.7.7"]
                  [expectations             "1.4.55"]
-                 [org.iq80.snappy/snappy   "0.3"]]
+                 [org.iq80.snappy/snappy   "0.3"]
+                 [net.jpountz.lz4/lz4      "1.2.0"]
+                 [primitive-math           "0.1.3"]]
   :profiles {:1.4   {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5   {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6   {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}

--- a/src/taoensso/nippy/compression.clj
+++ b/src/taoensso/nippy/compression.clj
@@ -1,7 +1,9 @@
 (ns taoensso.nippy.compression
   "Alpha - subject to change."
   {:author "Peter Taoussanis"}
-  (:require [taoensso.nippy.utils :as utils]))
+  (:require [taoensso.nippy.utils :as utils]
+            [primitive-math :as pm :refer [<< >>>]])
+  (:import (net.jpountz.lz4 LZ4Factory)))
 
 ;;;; Interface
 
@@ -18,3 +20,44 @@
 
 (def snappy-compressor "Default org.iq80.snappy.Snappy compressor."
   (->SnappyCompressor))
+
+
+;;;; LZ4 Compression
+
+(def ^net.jpountz.lz4.LZ4Factory LZ4-factory
+  (net.jpountz.lz4.LZ4Factory/fastestInstance))
+
+(def ^:const int-bytes (int 4))
+
+;; Stolen impl from cassandra where we prefix the compressed bytes
+;; array with the compressed length to make decompression faster
+(deftype LZ4Compressor
+    [^net.jpountz.lz4.LZ4Compressor compressor
+     ^net.jpountz.lz4.LZ4Decompressor decompressor]
+  ICompressor
+  (compress [_ ba]
+    (let [input-len (alength ^bytes ba)
+          max-compressed-length (.maxCompressedLength compressor input-len)
+          output (byte-array (pm/+ int-bytes max-compressed-length))]
+      (aset-byte output 0 (pm/byte (>>> input-len 24)))
+      (aset-byte output 1 (pm/byte (>>> input-len 16)))
+      (aset-byte output 2 (pm/byte (>>> input-len 8)))
+      (aset-byte output 3 (pm/byte input-len))
+      (.compress compressor ba 0 input-len output int-bytes max-compressed-length)
+      output))
+  (decompress [_ ba]
+    (let [uncompressed-len (pm/bit-or (<< (pm/byte->ubyte (aget ^bytes ba 0)) 24)
+                                      (<< (pm/byte->ubyte (aget ^bytes ba 1)) 16)
+                                      (<< (pm/byte->ubyte (aget ^bytes ba 2)) 8)
+                                      (pm/byte->ubyte (aget ^bytes ba 3)))
+          output (byte-array uncompressed-len)]
+      (.decompress decompressor ba int-bytes output 0 uncompressed-len)
+      output)))
+
+(def lz4-compressor "Default net.jpountz.lz4 compressor."
+  (->LZ4Compressor (.fastCompressor LZ4-factory)
+                   (.fastDecompressor LZ4-factory)))
+
+(def lz4hc-compressor "High compression net.jpountz.lz4 compressor."
+  (->LZ4Compressor (.highCompressor LZ4-factory)
+                   (.fastDecompressor LZ4-factory)))

--- a/test/taoensso/nippy/tests/main.clj
+++ b/test/taoensso/nippy/tests/main.clj
@@ -1,7 +1,8 @@
 (ns taoensso.nippy.tests.main
   (:require [expectations   :as test :refer :all]
             [taoensso.nippy :as nippy :refer (freeze thaw)]
-            [taoensso.nippy.benchmarks :as benchmarks]))
+            [taoensso.nippy.benchmarks :as benchmarks]
+            [taoensso.nippy.compression :refer [lz4-compressor lz4hc-compressor]]))
 
 ;; Remove stuff from stress-data that breaks roundtrip equality
 (def test-data (dissoc nippy/stress-data :bytes))
@@ -29,6 +30,16 @@
       (thaw (org.xerial.snappy.Snappy/uncompress iq80-ba))
       (thaw (org.iq80.snappy.Snappy/uncompress   iq80-ba    0 (alength iq80-ba)))
       (thaw (org.iq80.snappy.Snappy/uncompress   xerial-ba  0 (alength xerial-ba))))))
+
+(expect
+ (= test-data (thaw (freeze test-data
+                            {:compressor lz4-compressor})
+                    {:compressor lz4-compressor})))
+
+(expect
+ (= test-data (thaw (freeze test-data
+                            {:compressor lz4hc-compressor})
+                    {:compressor lz4hc-compressor})))
 
 ;;; Records (reflecting)
 (defrecord MyRec [data])


### PR DESCRIPTION
This is an initial implementation of LZ4 support. This is inspired by what is done on https://github.com/datastax/java-driver or https://github.com/ning/jvm-compressor-benchmark with regards to optimisations for decompression. 

related to #12 

I added a fairly simple test, it "seems" to be working with stress-data but I didn't dig deeper as it is a bit late here already :) 
