### PR TITLE
Expose exception to user as :throwable

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -436,8 +436,9 @@
         id-reader
         (let [edn (read-utf8 in)]
           (try (edn/read-string {:readers *data-readers*} edn)
-               (catch Exception _ {:nippy/unthawable edn
-                                   :type :reader})))
+               (catch Exception e {:nippy/unthawable edn
+                                   :type :reader
+                                   :throwable e})))
 
         id-serializable
         (let [class-name (read-utf8 in)]
@@ -446,8 +447,9 @@
                      object (.readObject (ObjectInputStream. in))
                      class ^Class (Class/forName class-name)]
                  (cast class object))
-               (catch Exception _ {:nippy/unthawable class-name
-                                   :type :serializable})))
+               (catch Exception e {:nippy/unthawable class-name
+                                   :type :serializable
+                                   :throwable e})))
 
         id-bytes   (read-bytes in)
         id-nil     nil
@@ -551,7 +553,7 @@
     nil            nil
     :aes128-sha512 aes128-encryptor
     :no-header     (throw (ex-info ":auto not supported on headerless data." {}))
-    :else (throw (ex-info ":auto not supported for non-standard encryptors."))
+    :else (throw (ex-info ":auto not supported for non-standard encryptors." {}))
     (throw (ex-info (format "Unrecognized :auto encryptor id: %s" encryptor-id)
                     {:encryptor-id encryptor-id}))))
 


### PR DESCRIPTION
This is related to #51.
The root cause of the issue was that clojure datastructures implement `Serializable` interface without having a serialVersionUID. I had filed a JIRA for this earlier http://dev.clojure.org/jira/browse/CLJ-1327.
With this change the error becomes evident to user of nippy which is otherwise ignored.

``` clj
{:nippy/unthawable "org.Dummy"
 :type :serializable
 :cause "clojure.lang.Keyword; local class incompatible: stream classdesc serialVersionUID = 412129
1061259229960, local class serialVersionUID = -6496198289950458564"}
```
