### PR TITLE
Add Fory to benchmarks

### DIFF
--- a/.github/workflows/graal-tests.yml
+++ b/.github/workflows/graal-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: deps-${{ hashFiles('deps.edn') }}
+          key: deps-${{ hashFiles('project.clj') }}
           restore-keys: deps-
 
       - name: Run Graal tests

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is used at scale by [Carmine](https://www.taoensso.com/carmine), [Faraday](ht
 
 - `2025-05-18` `v3.6.0`: [release info](../../releases/tag/v3.6.0)
 
-[![Main tests][Main tests SVG]][Main tests URL]
+[![Clj tests][Clj tests SVG]][Clj tests URL]
 [![Graal tests][Graal tests SVG]][Graal tests URL]
 
 See [here][GitHub releases] for earlier releases.
@@ -122,7 +122,7 @@ Licensed under [EPL 1.0](LICENSE.txt) (same as Clojure).
 [Clojars SVG]: https://img.shields.io/clojars/v/com.taoensso/nippy.svg
 [Clojars URL]: https://clojars.org/com.taoensso/nippy
 
-[Main tests SVG]:  https://github.com/taoensso/nippy/actions/workflows/main-tests.yml/badge.svg
-[Main tests URL]:  https://github.com/taoensso/nippy/actions/workflows/main-tests.yml
+[Clj tests SVG]:  https://github.com/taoensso/nippy/actions/workflows/clj-tests.yml/badge.svg
+[Clj tests URL]:  https://github.com/taoensso/nippy/actions/workflows/clj-tests.yml
 [Graal tests SVG]: https://github.com/taoensso/nippy/actions/workflows/graal-tests.yml/badge.svg
 [Graal tests URL]: https://github.com/taoensso/nippy/actions/workflows/graal-tests.yml

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,8 @@
 
     :dependencies
     [[org.clojure/test.check    "1.1.1"]
-     [org.clojure/data.fressian "1.1.0"]]
+     [org.clojure/data.fressian "1.1.0"]
+     [org.apache.fory/fory-core "0.11.1"]]
 
     :plugins
     [[lein-pprint  "1.3.2"]


### PR DESCRIPTION
I think it's worth adding [Fory](https://github.com/apache/fory) to the benchmarks. Based on tests on my machine, it freezes and thaws faster than nippy, but has significantly larger serialised sizes, which presents an interesting tradeoff. I can add my results to the PR if you'd like.


```clj
{:fory            {:round 1216, :freeze 382, :thaw 834, :size 41077},
 :reader          {:round 8611, :freeze 2425, :thaw 6186, :size 15880},
 :fressian        {:round 2467, :freeze 1623, :thaw 844, :size 12222},
 :nippy/lzma2     {:round 7251, :freeze 4459, :thaw 2792, :size 3888},
 :nippy/encrypted {:round 2281, :freeze 1088, :thaw 1193, :size 8550},
 :nippy/default   {:round 2229, :freeze 1079, :thaw 1150, :size 8522},
 :nippy/fast      {:round 1914, :freeze 828, :thaw 1086, :size 17098}}
```